### PR TITLE
move scores to different segment in Etterna.xml

### DIFF
--- a/src/Etterna/Models/Misc/XMLProfile.cpp
+++ b/src/Etterna/Models/Misc/XMLProfile.cpp
@@ -491,7 +491,7 @@ XMLProfile::LoadEttXmlFromNode(const XNode* xml)
 	if (play)
 		LoadPlaylistsFromNode(play);
 
-	auto scores = xml->GetChild("PlayerScores");
+	auto scores = xml->GetChild("OsuOD8Scores");
 	if (scores)
 		LoadEttScoresFromNode(scores);
 

--- a/src/Etterna/Singletons/ScoreManager.cpp
+++ b/src/Etterna/Singletons/ScoreManager.cpp
@@ -1119,7 +1119,7 @@ ScoresForChart::CreateNode(const string& ck) const -> XNode*
 auto
 ScoreManager::CreateNode(const string& profileID) const -> XNode*
 {
-	auto* o = new XNode("PlayerScores");
+	auto* o = new XNode("OsuOD8Scores");
 	for (const auto& ch : pscores.find(profileID)->second) {
 		auto* const node = ch.second.CreateNode(ch.first);
 		if (!node->ChildrenEmpty()) {


### PR DESCRIPTION
Now ShanghaiMoon scores are saved under "OsuOD8Scores" node in Etterna.xml, thus invalidating the .xml from submitting to etternaonline.